### PR TITLE
Adding gitignore file for WordPress and Grunt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+.gi # Created by .ignore support plugin (hsz.mobi)
+### WordPress template
+.idea/
+*.log
+.htaccess
+sitemap.xml
+sitemap.xml.gz
+wp-config.php
+wp-content/advanced-cache.php
+wp-content/backup-db/
+wp-content/backups/
+wp-content/blogs.dir/
+wp-content/cache/
+wp-content/upgrade/
+wp-content/uploads/
+wp-content/wp-cache-config.php
+#ignore code coverage results
+/log
+#ignore node_modules for grunt
+node_modules
+npm-debug.log
+


### PR DESCRIPTION
Adding gitignore file. git ignore will help us in keeping unrelated WordPress and node.js\grunt.js files out of the git repository. 