### PR TITLE
 Adding phpcs and secturity fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+# This uses newer and faster docker based build system
+sudo: false
+
+language: php
+
+notifications:
+  on_success: never
+  on_failure: change
+
+php:
+  - nightly # PHP 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+
+env:
+  - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+before_script:
+  # Install composer packages before trying to activate themes or plugins
+  # - composer install
+
+  - git clone https://github.com/dorzki/Slack-Notifications.git
+  - bash tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
+
+script:
+  - phpcs --standard=WordPress ./**/*.php
+#  - phpunit
+#  - cd tests/rspec && bundle exec rspec test.rb

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
     grunt.initConfig({ //object with all tasks.
         phpcs: {
             application: {
-                src: ['./**/*.php']
+                src: ['./**/*.php', '!./node_modules/**']
             },
             options: {
                 standard: 'WordPress',
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
         },
         phpcbf: {
             files: {
-                src: ['./**/*.php']
+                src: ['./**/*.php', '!./node_modules/**']
             },
             options: {
                 standard: 'WordPress',

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -1,14 +1,14 @@
 <?php
 /**
+ * Slack Bot Class.
+ *
  * @package   Slack Notifications
  * @since     1.0.0
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- *
- *
- * SLACK BOT CLASS
  */
+
 if ( ! class_exists( slackBot ) ) {
 
 	class slackBot {

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -84,7 +84,7 @@ if ( ! class_exists( slackBot ) ) {
 				'blocking'    => true,
 				'headers'     => array(),
 				'body'        => array(
-				'payload'   => json_encode( array(
+				'payload'   => wp_json_encode( array(
 					'channel'  => $this->slackChannel,
 					'username' => $this->botName,
 					'icon_url' => $this->botIcon,

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -11,6 +11,9 @@
 
 if ( ! class_exists( SlackBot ) ) {
 
+	/**
+	 * Class SlackBot
+	 */
 	class SlackBot {
 
 		/**

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -9,9 +9,9 @@
  * @link      https://www.dorzki.co.il
  */
 
-if ( ! class_exists( slackBot ) ) {
+if ( ! class_exists( SlackBot ) ) {
 
-	class slackBot {
+	class SlackBot {
 
 		/**
 		 * Slack Webhook Endpoint

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -65,8 +65,8 @@ if ( ! class_exists( SlackBot ) ) {
 
 			$this->apiEndpoint  = get_option( 'slack_webhook_endpoint' );
 			$this->slackChannel = get_option( 'slack_channel_name' );
-			$this->botName      = ( get_option( 'slack_bot_username' ) == '' ) ? 'Slack Bot' : get_option( 'slack_bot_username' );
-			$this->botIcon      = ( get_option( 'slack_bot_image' ) == '' ) ? PLUGIN_ROOT_URL . 'assets/images/default-bot-icon.png' : get_option( 'slack_bot_image' );
+			$this->botName      = ( get_option( 'slack_bot_username' ) === '' ) ? 'Slack Bot' : get_option( 'slack_bot_username' );
+			$this->botIcon      = ( get_option( 'slack_bot_image' ) === '' ) ? PLUGIN_ROOT_URL . 'assets/images/default-bot-icon.png' : get_option( 'slack_bot_image' );
 
 		}
 

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -78,7 +78,7 @@ if ( ! class_exists( SlackBot ) ) {
 		 * @param   string $theMessage   the notification to send.
 		 * @since   1.0.0
 		 */
-		public function sendMessage( $theMessage ) {
+		public function send_message( $theMessage ) {
 
 			$apiResponse = wp_remote_post( $this->apiEndpoint, array(
 				'method'      => 'POST',

--- a/classes/slack-bot.php
+++ b/classes/slack-bot.php
@@ -5,8 +5,8 @@
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- * 
- * 
+ *
+ *
  * SLACK BOT CLASS
  */
 if ( ! class_exists( slackBot ) ) {
@@ -25,7 +25,7 @@ if ( ! class_exists( slackBot ) ) {
 
 		/**
 		 * Slack Channel
-		 * 
+		 *
 		 * @var 	  string
 		 * @since   1.0.0
 		 */
@@ -35,7 +35,7 @@ if ( ! class_exists( slackBot ) ) {
 
 		/**
 		 * Slack Name
-		 * 
+		 *
 		 * @var 	  string
 		 * @since   1.0.0
 		 */
@@ -45,7 +45,7 @@ if ( ! class_exists( slackBot ) ) {
 
 		/**
 		 * Slack Image
-		 * 
+		 *
 		 * @var 	  string
 		 * @since   1.0.0
 		 */
@@ -55,7 +55,7 @@ if ( ! class_exists( slackBot ) ) {
 
 		/**
 		 * Get slack bot details.
-		 * 
+		 *
 		 * @since   1.0.0
 		 */
 		public function __construct() {
@@ -71,8 +71,8 @@ if ( ! class_exists( slackBot ) ) {
 
 		/**
 		 * Send the notification thought the API.
-		 * 
-		 * @param   string  $theMessage   the notification to send.
+		 *
+		 * @param   string $theMessage   the notification to send.
 		 * @since   1.0.0
 		 */
 		public function sendMessage( $theMessage ) {
@@ -88,7 +88,7 @@ if ( ! class_exists( slackBot ) ) {
 					'channel'  => $this->slackChannel,
 					'username' => $this->botName,
 					'icon_url' => $this->botIcon,
-					'text'     => sprintf( '%s @ *<%s|%s>*', $theMessage, get_bloginfo( 'home' ), get_bloginfo( 'name' ) )
+					'text'     => sprintf( '%s @ *<%s|%s>*', $theMessage, get_bloginfo( 'home' ), get_bloginfo( 'name' ) ),
 				) ),
 				),
 			) );

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -5,8 +5,8 @@
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- * 
- * 
+ *
+ *
  * NOTIFICATIONS CLASS
  */
 if ( ! class_exists( wpNotifications ) ) {
@@ -15,7 +15,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Slack class handler.
-		 * 
+		 *
 		 * @var 	  slackBot
 		 * @since   1.0.0
 		 */
@@ -26,7 +26,7 @@ if ( ! class_exists( wpNotifications ) ) {
 		/**
 		 * Register the SlackBot for internal use.
 		 *
-     * @since   1.0.0
+		 * @since   1.0.0
 		 */
 		public function __construct() {
 
@@ -154,9 +154,9 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Send notification on published post.
-		 * 
-		 * @param   integer  $postID  the post id number.
-		 * @param   object   $post    post details object.
+		 *
+		 * @param   integer $postID  the post id number.
+		 * @param   object  $post    post details object.
 		 * @since   1.0.0
 		 */
 		public function postPublishNotif( $postID, $post ) {
@@ -175,9 +175,9 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Send notification on published page.
-		 * 
-		 * @param   integer  $postID  the page id number.
-		 * @param   object   $post    page details object.
+		 *
+		 * @param   integer $postID  the page id number.
+		 * @param   object  $post    page details object.
 		 * @since   1.0.0
 		 */
 		public function pagePublishNotif( $postID, $post ) {
@@ -196,9 +196,9 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Send notification when comment has been submitted.
-		 * 
-		 * @param   integer  $commentID    the comment id number.
-		 * @param   integer  $isApproved   has the comment approved?
+		 *
+		 * @param   integer $commentID    the comment id number.
+		 * @param   integer $isApproved   has the comment approved?
 		 * @since   1.0.0
 		 */
 		public function commentAddedNotif( $commentID, $isApproved ) {
@@ -220,8 +220,8 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Send notification on user registration.
-		 * 
-		 * @param   integer  $userID  the registered user id number.
+		 *
+		 * @param   integer $userID  the registered user id number.
 		 * @since   1.0.0
 		 */
 		public function userRegisteredNotif( $userID ) {
@@ -238,9 +238,9 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Send notification on administrator login.
-		 * 
-		 * @param   string  $username  the username.
-		 * @param   object  $user      the user details.
+		 *
+		 * @param   string $username  the username.
+		 * @param   object $user      the user details.
 		 * @since   1.0.0
 		 */
 		public function adminLoggedInNotif( $username, $user ) {
@@ -259,9 +259,9 @@ if ( ! class_exists( wpNotifications ) ) {
 
 		/**
 		 * Send notification on published custom post type.
-		 * 
-		 * @param   integer  $postID  the post id number.
-		 * @param   object   $post    page details object.
+		 *
+		 * @param   integer $postID  the post id number.
+		 * @param   object  $post    page details object.
 		 * @since   1.0.1
 		 */
 		public function cptPublishNotif( $postID, $post ) {

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -44,7 +44,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 *
 		 * @since   1.0.0
 		 */
-		public function coreUpdateNotif() {
+		public function core_update_notif() {
 
 			global $wp_version;
 
@@ -77,7 +77,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 *
 		 * @since   1.0.0
 		 */
-		public function themeUpdateNotif() {
+		public function theme_update_notif() {
 
 			// Force version check.
 			do_action( 'wp_update_themes' );

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -1,16 +1,19 @@
 <?php
 /**
+ * Notifications class
+ *
  * @package   Slack Notifications
  * @since     1.0.0
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- *
- *
- * NOTIFICATIONS CLASS
  */
+
 if ( ! class_exists( wpNotifications ) ) {
 
+	/**
+	 * Class wpNotifications
+	 */
 	class wpNotifications {
 
 		/**
@@ -198,7 +201,7 @@ if ( ! class_exists( wpNotifications ) ) {
 		 * Send notification when comment has been submitted.
 		 *
 		 * @param   integer $commentID    the comment id number.
-		 * @param   integer $isApproved   has the comment approved?
+		 * @param   integer $isApproved   has the comment approved?.
 		 * @since   1.0.0
 		 */
 		public function commentAddedNotif( $commentID, $isApproved ) {

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -142,7 +142,7 @@ if ( ! class_exists( WPNotifications ) ) {
 				update_option( 'slack_notif_plugins_version', $notifiedPlugins );
 
 				// Do we still need to notify?
-				if ( $theMessage != '' ) {
+				if ( '' !== $theMessage ) {
 
 					$theMessage = __( ':information_source: The following plugins have a new version:', 'dorzki-slack' ) . "\n" . $theMessage;
 

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -16,7 +16,7 @@ if ( ! class_exists( wpNotifications ) ) {
 		/**
 		 * Slack class handler.
 		 *
-		 * @var 	  slackBot
+		 * @var 	  SlackBot
 		 * @since   1.0.0
 		 */
 		private $slack;
@@ -30,7 +30,7 @@ if ( ! class_exists( wpNotifications ) ) {
 		 */
 		public function __construct() {
 
-			$this->slack = new slackBot();
+			$this->slack = new SlackBot();
 
 		}
 

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -9,12 +9,12 @@
  * @link      https://www.dorzki.co.il
  */
 
-if ( ! class_exists( wpNotifications ) ) {
+if ( ! class_exists( WPNotifications ) ) {
 
 	/**
-	 * Class wpNotifications
+	 * Class WPNotifications
 	 */
-	class wpNotifications {
+	class WPNotifications {
 
 		/**
 		 * Slack class handler.

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -60,7 +60,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 					update_option( 'slack_notif_core_version', $newVersion );
 
-					$this->slack->sendMessage( sprintf( __( ':information_source: There is a new WordPress version available - v%s (current version is v%s).' ), $newVersion, $wp_version ) );
+					$this->slack->send_message( sprintf( __( ':information_source: There is a new WordPress version available - v%s (current version is v%s).' ), $newVersion, $wp_version ) );
 
 				}
 			}
@@ -92,7 +92,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 					update_option( 'slack_notif_theme_version', $newVersion );
 
-					$this->slack->sendMessage( sprintf( __( ':information_source: Theme is a new version of the theme *%s* - v%s (current version is v%s).' ), $currentTheme, $newVersion, $currentVersion ) );
+					$this->slack->send_message( sprintf( __( ':information_source: Theme is a new version of the theme *%s* - v%s (current version is v%s).' ), $currentTheme, $newVersion, $currentVersion ) );
 
 				}
 			}
@@ -143,7 +143,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 					$theMessage = __( ':information_source: The following plugins have a new version:', 'dorzki-slack' ) . "\n" . $theMessage;
 
-					$this->slack->sendMessage( $theMessage );
+					$this->slack->send_message( $theMessage );
 
 				}
 			}
@@ -167,7 +167,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 			$template = sprintf( __( ':metal: The post *<%s|%s>* was published by *%s* right now!', 'dorzki-slack' ), $url, $title, $author );
 
-			$this->slack->sendMessage( $template );
+			$this->slack->send_message( $template );
 
 		}
 
@@ -188,7 +188,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 			$template = sprintf( __( ':metal: The page *<%s|%s>* was published by *%s* right now!', 'dorzki-slack' ), $url, $title, $author );
 
-			$this->slack->sendMessage( $template );
+			$this->slack->send_message( $template );
 
 		}
 
@@ -212,7 +212,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 			$template = sprintf( __( ':metal: A new comment by *%s* on *<%s|%s>*:', 'dorzki-slack' ) . "\n>>>%s", $author, $url, $post, $comment );
 
-			$this->slack->sendMessage( $template );
+			$this->slack->send_message( $template );
 
 		}
 
@@ -230,7 +230,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 			$template = sprintf( __( ':dancer: A new user just registered - *%s* (%s).', 'dorzki-slack' ), $user->user_login, $user->user_email );
 
-			$this->slack->sendMessage( $template );
+			$this->slack->send_message( $template );
 
 		}
 
@@ -249,7 +249,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 				$template = sprintf( __( ':bowtie: Administrator login: *%s*.', 'dorzki-slack' ), $username );
 
-				$this->slack->sendMessage( $template );
+				$this->slack->send_message( $template );
 
 			}
 
@@ -272,7 +272,7 @@ if ( ! class_exists( wpNotifications ) ) {
 
 			$template = sprintf( __( ':metal: The post *<%s|%s>* was published by *%s* right now!', 'dorzki-slack' ), $url, $title, $author );
 
-			$this->slack->sendMessage( $template );
+			$this->slack->send_message( $template );
 
 		}
 	}

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -54,12 +54,12 @@ if ( ! class_exists( WPNotifications ) ) {
 			$versionCheck = get_site_transient( 'update_core' );
 
 			// Is there a new version of WordPress?
-			if ( $versionCheck->updates[0]->response == 'upgrade' ) {
+			if ( $versionCheck->updates[0]->response === 'upgrade' ) {
 
 				$newVersion = $versionCheck->updates[0]->current;
 
 				// Did we already notified the admin?
-				if ( get_option( 'slack_notif_core_version' ) != $newVersion ) {
+				if ( get_option( 'slack_notif_core_version' ) !== $newVersion ) {
 
 					update_option( 'slack_notif_core_version', $newVersion );
 
@@ -86,12 +86,12 @@ if ( ! class_exists( WPNotifications ) ) {
 			$currentVersion = wp_get_theme()->get( 'Version' );
 			$currentTheme   = get_option( 'template' );
 
-			if ( $versionCheck->response[ $currentTheme ]['new_version'] != $currentVersion ) {
+			if ( $versionCheck->response[ $currentTheme ]['new_version'] !== $currentVersion ) {
 
 				$newVersion = $versionCheck->response[ $currentTheme ]['new_version'];
 
 				// Did we already notified the admin?
-				if ( get_option( 'slack_notif_theme_version' ) != $newVersion ) {
+				if ( get_option( 'slack_notif_theme_version' ) !== $newVersion ) {
 
 					update_option( 'slack_notif_theme_version', $newVersion );
 
@@ -130,7 +130,7 @@ if ( ! class_exists( WPNotifications ) ) {
 					$pluginMeta = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin, true, false );
 
 					// Did we already notified the admin?
-					if ( ! array_key_exists( $plugin, $notifiedPlugins ) && $notifiedPlugins[ $plugin ] != $updateData->new_version ) {
+					if ( ! array_key_exists( $plugin, $notifiedPlugins ) && $notifiedPlugins[ $plugin ] !== $updateData->new_version ) {
 
 						$notifiedPlugins[ $plugin ] = $updateData->new_version;
 

--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -109,7 +109,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 *
 		 * @since   1.0.0
 		 */
-		public function pluginUpdateNotif() {
+		public function plugin_update_notif() {
 
 			// Force version check.
 			do_action( 'wp_update_plugins' );
@@ -162,7 +162,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 * @param   object  $post    post details object.
 		 * @since   1.0.0
 		 */
-		public function postPublishNotif( $postID, $post ) {
+		public function post_publish_notif( $postID, $post ) {
 
 			$title  = $post->post_title;
 			$url    = get_permalink( $postID );
@@ -183,7 +183,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 * @param   object  $post    page details object.
 		 * @since   1.0.0
 		 */
-		public function pagePublishNotif( $postID, $post ) {
+		public function page_publish_notif( $postID, $post ) {
 
 			$title  = $post->post_title;
 			$url    = get_permalink( $postID );
@@ -204,7 +204,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 * @param   integer $isApproved   has the comment approved?.
 		 * @since   1.0.0
 		 */
-		public function commentAddedNotif( $commentID, $isApproved ) {
+		public function comment_added_notif( $commentID, $isApproved ) {
 
 			$commentData = get_comment( $commentID );
 
@@ -227,7 +227,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 * @param   integer $userID  the registered user id number.
 		 * @since   1.0.0
 		 */
-		public function userRegisteredNotif( $userID ) {
+		public function user_registered_notif( $userID ) {
 
 			$user = get_userdata( $userID );
 
@@ -246,7 +246,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 * @param   object $user      the user details.
 		 * @since   1.0.0
 		 */
-		public function adminLoggedInNotif( $username, $user ) {
+		public function admin_logged_in_notif( $username, $user ) {
 
 			if ( in_array( 'administrator', $user->roles ) ) {
 
@@ -267,7 +267,7 @@ if ( ! class_exists( WPNotifications ) ) {
 		 * @param   object  $post    page details object.
 		 * @since   1.0.1
 		 */
-		public function cptPublishNotif( $postID, $post ) {
+		public function cpt_publish_notif( $postID, $post ) {
 
 			$title  = $post->post_title;
 			$url    = get_permalink( $postID );

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -177,7 +177,7 @@ if ( ! class_exists( WPSlack ) ) {
 			global $postTypes;
 
 			if ( ! current_user_can( 'manage_options' ) ) {
-				wp_die( __( 'Oops... It\'s seems like you don\'t meet the required level of permissions', 'dorzki-slack' ) );
+				wp_die( esc_html__( 'Oops... It\'s seems like you don\'t meet the required level of permissions', 'dorzki-slack' ) );
 			}
 
 			$postTypes = $this->postTypes;

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -9,12 +9,12 @@
  * @link      https://www.dorzki.co.il
  */
 
-if ( ! class_exists( wpSlack ) ) {
+if ( ! class_exists( WPSlack ) ) {
 
 	/**
-	 * Class wpSlack
+	 * Class WPSlack
 	 */
-	class wpSlack {
+	class WPSlack {
 
 		/**
 		 * Registerd Post Types.

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -29,7 +29,7 @@ if ( ! class_exists( WPSlack ) ) {
 		/**
 		 * Notifications class handler.
 		 *
-		 * @var 	  wpNotifications
+		 * @var 	  WPNotifications
 		 * @since   1.0.1
 		 */
 		private $notifs;
@@ -44,7 +44,7 @@ if ( ! class_exists( WPSlack ) ) {
 		public function __construct() {
 
 			// Initiate the Notifications Class.
-			$this->notifs = new wpNotifications();
+			$this->notifs = new WPNotifications();
 
 			add_action( 'admin_init', array( &$this, 'plugin_init' ) );
 			add_action( 'init', array( &$this, 'plugin_translate' ) );

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -235,11 +235,11 @@ if ( ! class_exists( WPSlack ) ) {
 
 			// Register Hooks.
 			if ( 1 === $core_update ) {
-				add_action( 'slack_notif_check_versions', array( &$notifs, 'coreUpdateNotif' ) );
+				add_action( 'slack_notif_check_versions', array( &$notifs, 'core_update_notif' ) );
 			}
 
 			if ( 1 === $theme_update ) {
-				add_action( 'slack_notif_check_versions', array( &$notifs, 'themeUpdateNotif' ) );
+				add_action( 'slack_notif_check_versions', array( &$notifs, 'theme_update_notif' ) );
 			}
 
 			if ( 1 === $plugin_update ) {

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -1,16 +1,19 @@
 <?php
 /**
+ * WordPress Slack
+ *
  * @package   Slack Notifications
  * @since     1.0.0
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- *
- *
- * WORDPRESS CLASS
  */
+
 if ( ! class_exists( wpSlack ) ) {
 
+	/**
+	 * Class wpSlack
+	 */
 	class wpSlack {
 
 		/**
@@ -230,7 +233,7 @@ if ( ! class_exists( wpSlack ) ) {
 			$new_user = get_option( 'slack_notif_new_user' );
 			$admin_logged = get_option( 'slack_notif_admin_logged' );
 
-			// Register Hooks
+			// Register Hooks.
 			if ( $core_update == 1 ) {
 				add_action( 'slack_notif_check_versions', array( &$notifs, 'coreUpdateNotif' ) );
 			}

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -198,7 +198,7 @@ if ( ! class_exists( WPSlack ) ) {
 			wp_register_script( 'dorzki-slack-media-upload', PLUGIN_ROOT_URL . 'assets/js/admin-scripts.js' );
 			wp_register_style( 'dorzki-slack-settings-css', PLUGIN_ROOT_URL . 'assets/css/admin-styles.css' );
 
-			if ( get_current_screen()->id == 'settings_page_slack_notifications' ) {
+			if ( get_current_screen()->id === 'settings_page_slack_notifications' ) {
 
 				wp_enqueue_script( 'jquery' );
 				wp_enqueue_script( 'thickbox' );
@@ -234,35 +234,35 @@ if ( ! class_exists( WPSlack ) ) {
 			$admin_logged = get_option( 'slack_notif_admin_logged' );
 
 			// Register Hooks.
-			if ( $core_update == 1 ) {
+			if ( 1 === $core_update ) {
 				add_action( 'slack_notif_check_versions', array( &$notifs, 'coreUpdateNotif' ) );
 			}
 
-			if ( $theme_update == 1 ) {
+			if ( 1 === $theme_update ) {
 				add_action( 'slack_notif_check_versions', array( &$notifs, 'themeUpdateNotif' ) );
 			}
 
-			if ( $plugin_update == 1 ) {
+			if ( 1 === $plugin_update ) {
 				add_action( 'slack_notif_check_versions', array( &$notifs, 'pluginUpdateNotif' ) );
 			}
 
-			if ( $new_post == 1 ) {
+			if ( 1 === $new_post ) {
 				add_action( 'publish_post', array( &$notifs, 'postPublishNotif' ), 10, 2 );
 			}
 
-			if ( $new_page == 1 ) {
+			if ( 1 === $new_page ) {
 				add_action( 'publish_page', array( &$notifs, 'pagePublishNotif' ), 10, 2 );
 			}
 
-			if ( $new_comment == 1 ) {
+			if ( 1 === $new_comment ) {
 				add_action( 'comment_post', array( &$notifs, 'commentAddedNotif' ), 10, 2 );
 			}
 
-			if ( $new_user == 1 ) {
+			if ( 1 === $new_user ) {
 				add_action( 'user_register', array( &$notifs, 'userRegisteredNotif' ), 10, 1 );
 			}
 
-			if ( $admin_logged == 1 ) {
+			if ( 1 === $admin_logged ) {
 				add_action( 'wp_login', array( &$notifs, 'adminLoggedInNotif' ), 10, 2 );
 			}
 
@@ -320,7 +320,7 @@ if ( ! class_exists( WPSlack ) ) {
 			// Get selected settings for custom post types.
 			foreach ( $this->postTypes as $postType ) {
 
-				if ( get_option( 'slack_notif_new_' . $postType->name ) == 1 ) {
+				if ( get_option( 'slack_notif_new_' . $postType->name ) === 1 ) {
 
 					if ( has_action( 'publish_' . $postType->name, array( &$notifs, 'cptPublishNotif' ) ) === false ) {
 						add_action( 'publish_' . $postType->name, array( &$notifs, 'cptPublishNotif' ), 10, 2 );

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -5,8 +5,8 @@
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- * 
- * 
+ *
+ *
  * WORDPRESS CLASS
  */
 if ( ! class_exists( wpSlack ) ) {
@@ -25,7 +25,7 @@ if ( ! class_exists( wpSlack ) ) {
 
 		/**
 		 * Notifications class handler.
-		 * 
+		 *
 		 * @var 	  wpNotifications
 		 * @since   1.0.1
 		 */
@@ -101,7 +101,7 @@ if ( ! class_exists( wpSlack ) ) {
 			delete_option( 'slack_notif_plugins_version' );
 
 			// Delte custom post types settings.
-			foreach( $this->postTypes as $postType ) {
+			foreach ( $this->postTypes as $postType ) {
 
 				delete_option( 'slack_notif_new_' . $postType->name );
 
@@ -230,8 +230,6 @@ if ( ! class_exists( wpSlack ) ) {
 			$new_user = get_option( 'slack_notif_new_user' );
 			$admin_logged = get_option( 'slack_notif_admin_logged' );
 
-
-
 			// Register Hooks
 			if ( $core_update == 1 ) {
 				add_action( 'slack_notif_check_versions', array( &$notifs, 'coreUpdateNotif' ) );
@@ -279,7 +277,7 @@ if ( ! class_exists( wpSlack ) ) {
 			// Retrieve custom post types.
 			$this->postTypes = get_post_types( array(
 				'public' => true,
-				'_builtin' => false
+				'_builtin' => false,
 				), 'objects' );
 
 			add_action( 'admin_init', array( &$this, 'register_post_types_settings' ) );
@@ -295,7 +293,7 @@ if ( ! class_exists( wpSlack ) ) {
 		 */
 		public function register_post_types_settings() {
 
-			foreach( $this->postTypes as $postType ) {
+			foreach ( $this->postTypes as $postType ) {
 
 				register_setting( 'dorzki-slack', 'slack_notif_new_' . $postType->name );
 
@@ -309,7 +307,7 @@ if ( ! class_exists( wpSlack ) ) {
 
 		/**
 		 * Register custom post types notifications hooks.
-		 * 
+		 *
 		 * @since   1.0.1
 		 */
 		public function register_post_types_notifs_hooks() {
@@ -317,16 +315,14 @@ if ( ! class_exists( wpSlack ) ) {
 			$notifs = $this->notifs;
 
 			// Get selected settings for custom post types.
-			foreach( $this->postTypes as $postType ) {
+			foreach ( $this->postTypes as $postType ) {
 
 				if ( get_option( 'slack_notif_new_' . $postType->name ) == 1 ) {
 
 					if ( has_action( 'publish_' . $postType->name, array( &$notifs, 'cptPublishNotif' ) ) === false ) {
 						add_action( 'publish_' . $postType->name, array( &$notifs, 'cptPublishNotif' ), 10, 2 );
 					}
-
 				}
-
 			}
 
 		}

--- a/classes/wordpress-slack.php
+++ b/classes/wordpress-slack.php
@@ -243,27 +243,27 @@ if ( ! class_exists( WPSlack ) ) {
 			}
 
 			if ( 1 === $plugin_update ) {
-				add_action( 'slack_notif_check_versions', array( &$notifs, 'pluginUpdateNotif' ) );
+				add_action( 'slack_notif_check_versions', array( &$notifs, 'plugin_update_notif' ) );
 			}
 
 			if ( 1 === $new_post ) {
-				add_action( 'publish_post', array( &$notifs, 'postPublishNotif' ), 10, 2 );
+				add_action( 'publish_post', array( &$notifs, 'post_publish_notif' ), 10, 2 );
 			}
 
 			if ( 1 === $new_page ) {
-				add_action( 'publish_page', array( &$notifs, 'pagePublishNotif' ), 10, 2 );
+				add_action( 'publish_page', array( &$notifs, 'page_publish_notif' ), 10, 2 );
 			}
 
 			if ( 1 === $new_comment ) {
-				add_action( 'comment_post', array( &$notifs, 'commentAddedNotif' ), 10, 2 );
+				add_action( 'comment_post', array( &$notifs, 'comment_added_notif' ), 10, 2 );
 			}
 
 			if ( 1 === $new_user ) {
-				add_action( 'user_register', array( &$notifs, 'userRegisteredNotif' ), 10, 1 );
+				add_action( 'user_register', array( &$notifs, 'user_registered_notif' ), 10, 1 );
 			}
 
 			if ( 1 === $admin_logged ) {
-				add_action( 'wp_login', array( &$notifs, 'adminLoggedInNotif' ), 10, 2 );
+				add_action( 'wp_login', array( &$notifs, 'admin_logged_in_notif' ), 10, 2 );
 			}
 
 		}
@@ -322,8 +322,8 @@ if ( ! class_exists( WPSlack ) ) {
 
 				if ( get_option( 'slack_notif_new_' . $postType->name ) === 1 ) {
 
-					if ( has_action( 'publish_' . $postType->name, array( &$notifs, 'cptPublishNotif' ) ) === false ) {
-						add_action( 'publish_' . $postType->name, array( &$notifs, 'cptPublishNotif' ), 10, 2 );
+					if ( has_action( 'publish_' . $postType->name, array( &$notifs, 'cpt_publish_notif' ) ) === false ) {
+						add_action( 'publish_' . $postType->name, array( &$notifs, 'cpt_publish_notif' ), 10, 2 );
 					}
 				}
 			}

--- a/index.php
+++ b/index.php
@@ -1,2 +1,12 @@
 <?php
-// Nothing to see here
+/**
+ * Silence is golden.
+ *
+ * @package   Slack Notifications
+ * @since     1.0.0
+ * @version   1.0.1
+ * @author    Dor Zuberi <me@dorzki.co.il>
+ * @link      https://www.dorzki.co.il
+ */
+
+/* Silence is golden.*/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<phpunit bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true"
+         convertErrorsToExceptions   = "true"
+         convertNoticesToExceptions  = "true"
+         convertWarningsToExceptions = "true">
+    <testsuites>
+        <testsuite>
+            <directory prefix="test_" suffix=".php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./</directory>
+            <exclude>
+                <directory suffix=".php">tests</directory>
+                <directory suffix=".php">node_modules</directory>
+                <directory suffix=".php">**/assets</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-html" target="./log/codeCoverage" charset="UTF-8" highlight="true"
+             lowUpperBound="50" highLowerBound="80"/>
+        <log type="testdox-html" target="./log/testdox.html" />
+    </logging>
+</phpunit>

--- a/slack-notifications.php
+++ b/slack-notifications.php
@@ -18,7 +18,7 @@
 /**
  * PLUGIN CONSTANTS
  */
-if ( ! defined( PLUGIN_ROOT_URL ) ) {
+if ( ! defined( 'PLUGIN_ROOT_URL' ) ) {
 	define( PLUGIN_ROOT_URL, plugin_dir_url( __FILE__ ) );
 }
 

--- a/slack-notifications.php
+++ b/slack-notifications.php
@@ -44,12 +44,12 @@ include_once( 'classes/wordpress-slack.php' );
 /**
  * PLUGIN INITIALIZATION
  */
-$wpSlack = new wpSlack();
+$WPSlack = new WPSlack();
 
 
 
 /**
  * REGISTER ACTIVATION & DEACTIVATION
  */
-register_activation_hook( __FILE__, array( &$wpSlack, 'plugin_activate' ) );
-register_deactivation_hook( __FILE__, array( &$wpSlack, 'plugin_deactivate' ) );
+register_activation_hook( __FILE__, array( &$WPSlack, 'plugin_activate' ) );
+register_deactivation_hook( __FILE__, array( &$WPSlack, 'plugin_deactivate' ) );

--- a/slack-notifications.php
+++ b/slack-notifications.php
@@ -8,7 +8,6 @@
  * Author URI: https://www.dorzki.co.il
  * Text Domain: dorzki-slack
  *
- * 
  * @package   Slack Notifications
  * @since     1.0.0
  * @version   1.0.1

--- a/slack-notifications.php
+++ b/slack-notifications.php
@@ -15,10 +15,8 @@
  * @link      https://www.dorzki.co.il
  */
 
-
-
 /**
- * PLUGIN CONSTACTS
+ * PLUGIN CONSTANTS
  */
 if ( ! defined( PLUGIN_ROOT_URL ) ) {
 	define( PLUGIN_ROOT_URL, plugin_dir_url( __FILE__ ) );
@@ -44,7 +42,7 @@ include_once( 'classes/wordpress-slack.php' );
 
 
 /**
- * PLUGIN INTIALIZATION
+ * PLUGIN INITIALIZATION
  */
 $wpSlack = new wpSlack();
 

--- a/templates/settings-page.php
+++ b/templates/settings-page.php
@@ -1,15 +1,13 @@
 <?php
 /**
+ * Settings page.
+ *
  * @package   Slack Notifications
  * @since     1.0.0
  * @version   1.0.1
  * @author    Dor Zuberi <me@dorzki.co.il>
  * @link      https://www.dorzki.co.il
- *
- *
- * SETTINGS PAGE
  */
-
 
 global $postTypes;
 
@@ -23,59 +21,58 @@ $new_user = get_option( 'slack_notif_new_user' );
 $admin_logged = get_option( 'slack_notif_admin_logged' );
 ?>
 <div class="wrap">
-  <h2><?php _e( 'Slack Notifications', 'dorzki-slack' ); ?>
-    <small><?php _e( 'by', 'dorzki-slack' ); ?> <a href="https://www.dorzki.co.il" target="_blank"><?php _e( 'dorzki', 'dorzki-slack' ); ?></a></small>
+  <h2><?php esc_html_e( 'Slack Notifications', 'dorzki-slack' ); ?>
+    <small><?php esc_html_e( 'by', 'dorzki-slack' ); ?> <a href="https://www.dorzki.co.il" target="_blank"><?php esc_html_e( 'dorzki', 'dorzki-slack' ); ?></a></small>
   </h2>
   <form action="options.php" method="post">
     <?php settings_fields( 'dorzki-slack' ); ?>
-    <?php do_settings_fields( 'dorzki-slack' ); ?>
 
-    <h3 class="title"><?php _e( 'Integration Setup', 'dorzki-slack' ); ?></h3>
-    <p><?php _e( 'Setup the integration between WordPress and Slack API.', 'dorzki-slack' ); ?></p>
+    <h3 class="title"><?php esc_html_e( 'Integration Setup', 'dorzki-slack' ); ?></h3>
+    <p><?php esc_html_e( 'Setup the integration between WordPress and Slack API.', 'dorzki-slack' ); ?></p>
     <table class="form-table">
       <tbody>
 
         <!-- Webhook URL -->
         <tr valign="top">
-          <th scope="row"><label for="slack_webhook_endpoint"><?php _e( 'Webhooks Endpoint', 'dorzki-slack' ); ?></label></th>
+          <th scope="row"><label for="slack_webhook_endpoint"><?php esc_html_e( 'Webhooks Endpoint', 'dorzki-slack' ); ?></label></th>
           <td>
-            <input type="url" name="slack_webhook_endpoint" id="slack_webhook_endpoint" class="regular-text" value="<?php echo get_option( 'slack_webhook_endpoint' ); ?>">
-            <p class="description" id="slack_webhook_endpoint-description"><?php printf( __( 'Add <a href=\'%s\' target=\'_blank\'>Slack Incoming Webhooks</a> to your Slack Account and paste the Webhook URL here.', 'dorzki-slack' ), 'https://my.slack.com/services/new/incoming-webhook/' ); ?></p>
+            <input type="url" name="slack_webhook_endpoint" id="slack_webhook_endpoint" class="regular-text" value="<?php echo esc_html( get_option( 'slack_webhook_endpoint' ) ); ?>">
+            <p class="description" id="slack_webhook_endpoint-description"><?php printf( 'Add <a href=\'%s\' target=\'_blank\'>Slack Incoming Webhooks</a> to your Slack Account and paste the Webhook URL here.', 'dorzki-slack' , 'https://my.slack.com/services/new/incoming-webhook/' ); ?></p>
           </td>
         </tr>
         <!-- /Webhook URL -->
 
         <!-- Channel Name -->
         <tr valign="top">
-          <th scope="row"><label for="slack_channel_name"><?php _e( 'Channel Name', 'dorzki-slack' ); ?></label></th>
+          <th scope="row"><label for="slack_channel_name"><?php esc_html_e( 'Channel Name', 'dorzki-slack' ); ?></label></th>
           <td>
-            <input type="text" name="slack_channel_name" id="slack_channel_name" class="regular-text" value="<?php echo get_option( 'slack_channel_name' ); ?>">
-            <p class="description" id="slack_channel_name-description"><?php _e( 'Write here the desired channel name to receive notifications, don\'t forget to include the hash symbol before the name.', 'dorzki-slack' ); ?></p>
+            <input type="text" name="slack_channel_name" id="slack_channel_name" class="regular-text" value="<?php echo esc_html( get_option( 'slack_channel_name' ) ); ?>">
+            <p class="description" id="slack_channel_name-description"><?php esc_html_e( 'Write here the desired channel name to receive notifications, don\'t forget to include the hash symbol before the name.', 'dorzki-slack' ); ?></p>
           </td>
         </tr>
         <!-- /Channel Name -->
 
         <!-- Slack Bot Name -->
         <tr valign="top">
-          <th scope="row"><label for="slack_bot_username"><?php _e( 'Slack Bot Name', 'dorzki-slack' ); ?></label></th>
+          <th scope="row"><label for="slack_bot_username"><?php esc_html_e( 'Slack Bot Name', 'dorzki-slack' ); ?></label></th>
           <td>
-            <input type="text" name="slack_bot_username" id="slack_bot_username" class="regular-text" value="<?php echo get_option( 'slack_bot_username' ); ?>">
-            <p class="description" id="slack_bot_username-description"><?php _e( 'The Slack Bot name to be displayed in notifications.', 'dorzki-slack' ); ?></p>
+            <input type="text" name="slack_bot_username" id="slack_bot_username" class="regular-text" value="<?php echo esc_html( get_option( 'slack_bot_username' ) ); ?>">
+            <p class="description" id="slack_bot_username-description"><?php esc_html_e( 'The Slack Bot name to be displayed in notifications.', 'dorzki-slack' ); ?></p>
           </td>
         </tr>
         <!-- /Slack Bot Name -->
 
         <!-- Bot Image -->
         <tr valign="top">
-          <th scope="row"><label for="slack_bot_image"><?php _e( 'Slack Bot Logo', 'dorzki-slack' ); ?></label></th>
+          <th scope="row"><label for="slack_bot_image"><?php esc_html_e( 'Slack Bot Logo', 'dorzki-slack' ); ?></label></th>
           <td>
             <input type="text" id="slack_bot_image" name="slack_bot_image" class="regular-text" value="<?php echo esc_url( get_option( 'slack_bot_image' ) ); ?>" />
-            <input id="slack_bot_image_button" type="button" class="button" value="<?php _e( 'Upload', 'dorzki-slack' ); ?>" />
-            <p class="description" id="slack_bot_image-description"><?php _e( 'Slack Bot image to be displayed in Slack.', 'dorzki-slack' ); ?></p>
+            <input id="slack_bot_image_button" type="button" class="button" value="<?php esc_html_e( 'Upload', 'dorzki-slack' ); ?>" />
+            <p class="description" id="slack_bot_image-description"><?php esc_html_e( 'Slack Bot image to be displayed in Slack.', 'dorzki-slack' ); ?></p>
             <div id="slack_bot_image_preview">
-              <?php if ( get_option( 'slack_bot_image' ) != '' ) : ?>
-                <img src="<?php echo get_option( 'slack_bot_image' ); ?>">
-              <?php endif; ?>
+				<?php if ( '' !== get_option( 'slack_bot_image' )  ) : ?>
+                <img src="<?php echo esc_url( get_option( 'slack_bot_image' ) ); ?>">
+				<?php endif; ?>
             </div>
           </td>
         </tr>
@@ -83,36 +80,36 @@ $admin_logged = get_option( 'slack_notif_admin_logged' );
 
       </tbody>
     </table>
-    <h3 class="title"><?php _e( 'Desired Notifications', 'dorzki-slack' ); ?></h3>
-    <p><?php _e( 'Please select the desired notification to be sent on event fire.', 'dorzki-slack' ); ?></p>
+    <h3 class="title"><?php esc_html_e( 'Desired Notifications', 'dorzki-slack' ); ?></h3>
+    <p><?php esc_html_e( 'Please select the desired notification to be sent on event fire.', 'dorzki-slack' ); ?></p>
     <table class="form-table">
       <tbody>
 
         <tr>
-          <th scope="row"><?php _e( 'Version Updates', 'dorzki-slack' ); ?></th>
+          <th scope="row"><?php esc_html_e( 'Version Updates', 'dorzki-slack' ); ?></th>
           <td>
             <fieldset>
               <legend class="screen-reader-text">
-                <span><?php _e( 'Version Updates', 'dorzki-slack' ); ?></span>
+                <span><?php esc_html_e( 'Version Updates', 'dorzki-slack' ); ?></span>
               </legend>
 
               <!-- WordPress Core Update? -->
               <label for="slack_notif_core_update">
-                <input type="checkbox" name="slack_notif_core_update" id="slack_notif_core_update" value="1" <?php checked( $core_update, 1, true ); ?>> <?php _e( 'WordPress Core Update Available?', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_core_update" id="slack_notif_core_update" value="1" <?php checked( $core_update, 1, true ); ?>> <?php esc_html_e( 'WordPress Core Update Available?', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /WordPress Core Update? -->
 
               <!-- WordPress Theme Update? -->
               <label for="slack_notif_theme_update">
-                <input type="checkbox" name="slack_notif_theme_update" id="slack_notif_theme_update" value="1" <?php checked( $theme_update, 1, true ); ?>> <?php _e( 'Theme Update Available?', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_theme_update" id="slack_notif_theme_update" value="1" <?php checked( $theme_update, 1, true ); ?>> <?php esc_html_e( 'Theme Update Available?', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /WordPress Theme Update? -->
 
               <!-- WordPress Plugin Update? -->
               <label for="slack_notif_plugin_update">
-                <input type="checkbox" name="slack_notif_plugin_update" id="slack_notif_plugin_update" value="1" <?php checked( $plugin_update, 1, true ); ?>> <?php _e( 'Plugin Update Available?', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_plugin_update" id="slack_notif_plugin_update" value="1" <?php checked( $plugin_update, 1, true ); ?>> <?php esc_html_e( 'Plugin Update Available?', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /WordPress Plugin Update? -->
@@ -121,39 +118,39 @@ $admin_logged = get_option( 'slack_notif_admin_logged' );
           </td>
         </tr>
         <tr>
-          <th scope="row"><?php _e( 'New Entries', 'dorzki-slack' ); ?></th>
+          <th scope="row"><?php esc_html_e( 'New Entries', 'dorzki-slack' ); ?></th>
           <td>
             <fieldset>
               <legend class="screen-reader-text">
-                <span><?php _e( 'New Entries', 'dorzki-slack' ); ?></span>
+                <span><?php esc_html_e( 'New Entries', 'dorzki-slack' ); ?></span>
               </legend>
 
               <!-- New Post -->
               <label for="slack_notif_new_post">
-                <input type="checkbox" name="slack_notif_new_post" id="slack_notif_new_post" value="1" <?php checked( $new_post, 1, true ); ?>> <?php _e( 'Post Published', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_new_post" id="slack_notif_new_post" value="1" <?php checked( $new_post, 1, true ); ?>> <?php esc_html_e( 'Post Published', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /New Post -->
 
               <!-- New Page -->
               <label for="slack_notif_new_page">
-                <input type="checkbox" name="slack_notif_new_page" id="slack_notif_new_page" value="1" <?php checked( $new_page, 1, true ); ?>> <?php _e( 'Page Published', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_new_page" id="slack_notif_new_page" value="1" <?php checked( $new_page, 1, true ); ?>> <?php esc_html_e( 'Page Published', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /New Page -->
 
-              <?php foreach( $postTypes as $postType ) : ?>
-                <!-- New <?php echo $postType->labels->singular_name; ?> -->
-                <label for="slack_notif_new_<?php echo $postType->name; ?>">
-                  <input type="checkbox" name="slack_notif_new_<?php echo $postType->name; ?>" id="slack_notif_new_<?php echo $postType->name; ?>" value="1" <?php checked( intval( get_option( 'slack_notif_new_' . $postType->name ) ), 1, true ); ?>> <?php printf( __( '%s Published', 'dorzki-slack' ), $postType->labels->singular_name ); ?>
+				<?php foreach ( $postTypes as $postType ) : ?>
+                <!-- New <?php echo esc_html( $postType->labels->singular_name ); ?> -->
+                <label for="slack_notif_new_<?php echo esc_html( $postType->name ); ?>">
+                  <input type="checkbox" name="slack_notif_new_<?php echo esc_html( $postType->name ); ?>" id="slack_notif_new_<?php echo esc_html( $postType->name ); ?>" value="1" <?php checked( intval( get_option( 'slack_notif_new_' . $postType->name ) ), 1, true ); ?>> <?php printf( esc_html__( '%s Published', 'dorzki-slack' ), esc_html( $postType->labels->singular_name ) ); ?>
                 </label>
                 <br>
-                <!-- /New <?php echo $postType->labels->singular_name; ?> -->
-              <?php endforeach; ?>
+                <!-- /New <?php echo esc_html( $postType->labels->singular_name ); ?> -->
+				<?php endforeach; ?>
 
               <!-- New Comment -->
               <label for="slack_notif_new_comment">
-                <input type="checkbox" name="slack_notif_new_comment" id="slack_notif_new_comment" value="1" <?php checked( $new_comment, 1, true ); ?>> <?php _e( 'New Comment', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_new_comment" id="slack_notif_new_comment" value="1" <?php checked( $new_comment, 1, true ); ?>> <?php esc_html_e( 'New Comment', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /New Comment -->
@@ -162,23 +159,23 @@ $admin_logged = get_option( 'slack_notif_admin_logged' );
           </td>
         </tr>
         <tr>
-          <th scope="row"><?php _e( 'Users', 'dorzki-slack' ); ?></th>
+          <th scope="row"><?php esc_html_e( 'Users', 'dorzki-slack' ); ?></th>
           <td>
             <fieldset>
               <legend class="screen-reader-text">
-                <span><?php _e( 'Users', 'dorzki-slack' ); ?></span>
+                <span><?php esc_html_e( 'Users', 'dorzki-slack' ); ?></span>
               </legend>
 
               <!-- New User -->
               <label for="slack_notif_new_user">
-                <input type="checkbox" name="slack_notif_new_user" id="slack_notif_new_user" value="1" <?php checked( $new_user, 1, true ); ?>> <?php _e( 'New User', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_new_user" id="slack_notif_new_user" value="1" <?php checked( $new_user, 1, true ); ?>> <?php esc_html_e( 'New User', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /New User -->
 
               <!-- Admin Logged-in -->
               <label for="slack_notif_admin_logged">
-                <input type="checkbox" name="slack_notif_admin_logged" id="slack_notif_admin_logged" value="1" <?php checked( $admin_logged, 1, true ); ?>> <?php _e( 'Admin Logged-in', 'dorzki-slack' ); ?>
+                <input type="checkbox" name="slack_notif_admin_logged" id="slack_notif_admin_logged" value="1" <?php checked( $admin_logged, 1, true ); ?>> <?php esc_html_e( 'Admin Logged-in', 'dorzki-slack' ); ?>
               </label>
               <br>
               <!-- /Admin Logged-in -->

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+##
+# This script installs wordpress for phpunit tests and rspec integration tests
+##
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$(dirname ${DIR})
+
+if [ $# -lt 3 ]; then
+echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+
+WP_VERSION=${5-latest}
+
+# Use this for installing wordpress siteurl
+WP_TEST_URL=${WP_TEST_URL-http://localhost:12000}
+
+# Get port from url
+WP_PORT=${WP_TEST_URL##*:}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib/includes}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+# Use these credentials for installing wordpress
+# Default test/test
+WP_TEST_USER=${WP_TEST_USER-test}
+WP_TEST_USER_PASS=${WP_TEST_USER_PASS-test}
+
+set -ex
+
+download() {
+  if [ `which curl` ]; then
+    curl -s "$1" > "$2";
+  elif [ `which wget` ]; then
+    wget -nv -O "$2" "$1"
+  fi
+}
+
+install_wp() {
+  if [ -d $WP_CORE_DIR ]; then
+    return;
+  fi
+
+  mkdir -p $WP_CORE_DIR
+
+  if [ $WP_VERSION == 'latest' ]; then
+    local ARCHIVE_NAME='latest'
+  else
+    local ARCHIVE_NAME="wordpress-$WP_VERSION"
+  fi
+
+  download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+  tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+  download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+  # portable in-place argument for both GNU sed and Mac OSX sed
+  if [[ $(uname -s) == 'Darwin' ]]; then
+    local ioption='-i .bak'
+  else
+    local ioption='-i'
+  fi
+
+  # set up testing suite if it doesn't yet exist
+  if [ ! "$(ls -A $WP_TESTS_DIR)" ]; then
+    # set up testing suite
+    mkdir -p $WP_TESTS_DIR
+      #if latest, use trunk develop version, if not, use major version
+      if [ $WP_VERSION == 'latest' ]; then
+        local TEST_BRANCH_NAME='trunk'
+      else
+        local TEST_BRANCH_NAME='branches/'$(sed 's/\([0-9]*\.[0-9]*\).*/\1/' <<< $WP_VERSION)
+      fi
+    svn co --quiet http://develop.svn.wordpress.org/${TEST_BRANCH_NAME}/tests/phpunit/includes/ $WP_TESTS_DIR
+  fi
+
+  cd $WP_TESTS_DIR
+
+  # Install barebone wp-tests-config.php which is faster for unit tests
+  if [ ! -f wp-tests-config.php ]; then
+    download https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+    sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+    sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+    sed $ioption "s/yourusernamehere/$DB_USER/" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+    sed $ioption "s/yourpasswordhere/$DB_PASS/" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+    sed $ioption "s|localhost|${DB_HOST}|" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+  fi
+
+  # Install real wp-config.php too
+  cd $WP_CORE_DIR
+
+  if [ ! -f wp-config.php ]; then
+    mv wp-config-sample.php wp-config.php
+    sed $ioption "s/database_name_here/$DB_NAME/" $WP_CORE_DIR/wp-config.php
+    sed $ioption "s/username_here/$DB_USER/" $WP_CORE_DIR/wp-config.php
+    sed $ioption "s/password_here/$DB_PASS/" $WP_CORE_DIR/wp-config.php
+    sed $ioption "s|localhost|${DB_HOST}|" $WP_CORE_DIR/wp-config.php
+    # Use different prefix for integration tests
+    sed $ioption "s|^.*\$table_prefix.*$|\$table_prefix  = 'integ_';|" $WP_CORE_DIR/wp-config.php
+  fi
+}
+
+install_db() {
+  # parse DB_HOST for port or socket references
+  local PARTS=(${DB_HOST//\:/ })
+  local DB_HOSTNAME=${PARTS[0]};
+  local DB_SOCK_OR_PORT=${PARTS[1]};
+  local EXTRA=""
+
+  if ! [ -z $DB_HOSTNAME ] ; then
+    if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+      EXTRA="--host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+    elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+      EXTRA="--socket=$DB_SOCK_OR_PORT"
+    elif ! [ -z $DB_HOSTNAME ] ; then
+      EXTRA="--host=$DB_HOSTNAME --protocol=tcp"
+    fi
+  fi
+
+  # create database
+  mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS" $EXTRA
+}
+
+link_this_project() {
+  cd $DIR
+  local FOLDER_PATH=$(dirname $DIR)
+  local FOLDER_NAME=$(basename $FOLDER_PATH)
+  case $WP_PROJECT_TYPE in
+    'plugin' )
+        ln -s $FOLDER_PATH $WP_CORE_DIR/wp-content/plugins/$FOLDER_NAME
+        php wp-cli.phar plugin activate --all --path=$WP_CORE_DIR
+        ;;
+    'theme' )
+        ln -s $FOLDER_PATH $WP_CORE_DIR/wp-content/themes/$FOLDER_NAME
+        php wp-cli.phar theme activate $FOLDER_NAME --path=$WP_CORE_DIR
+        ;;
+  esac
+}
+
+# Install databases with wp-cli
+install_real_wp() {
+  cd $DIR
+  download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli.phar
+  php wp-cli.phar core install  --url=$WP_TEST_URL --title='Test' --admin_user=$WP_TEST_USER --admin_password=$WP_TEST_USER_PASS --admin_email="$WP_TEST_USER@wordpress.dev" --path=$WP_CORE_DIR
+}
+
+install_rspec_requirements() {
+  gem install bundler
+  bundle install --gemfile=$DIR/spec/Gemfile
+}
+
+start_server() {
+  mv $DIR/lib/router.php $WP_CORE_DIR/router.php
+  cd $WP_CORE_DIR
+  # Start it in background
+  php -S 0.0.0.0:$WP_PORT router.php &
+}
+
+run_phpcs() {
+  pear config-set auto_discover 1
+  pear install PHP_CodeSniffer
+  git clone git://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/WordPress
+  phpenv rehash
+  npm install -g jshint
+  phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards/WordPress
+  phpcs -i
+}
+
+install_wp
+install_test_suite
+install_db
+install_real_wp
+link_this_project
+#install_rspec_requirements
+start_server
+run_phpcs

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Bootstrap.
+ *
+ * @package   Slack Notifications
+ * @since     1.0.0
+ * @version   1.0.1
+ * @author    Ran Bar-Zik <ran@bar-zik.com>
+ * @license   GPL-2.0+
+ * @link      http://internet-israel.com
+ */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
@@ -16,6 +26,9 @@ $GLOBALS['wp_tests_options'] = array(
 
 require_once $_tests_dir . '/includes/functions.php';
 
+/**
+ * Loading the plugin.
+ */
 function _manually_load_plugin() {
 	require dirname( __DIR__ ) . '/'.PLUGIN_NAME;
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+define( 'PLUGIN_NAME', 'slack-notifications.php' );
+define( 'PLUGIN_FOLDER', basename( dirname( __DIR__ ) ) );
+define( 'PLUGIN_PATH', PLUGIN_FOLDER.'/'.PLUGIN_NAME );
+
+// Activates this plugin in WordPress so it can be tested.
+$GLOBALS['wp_tests_options'] = array(
+	'active_plugins' => array( PLUGIN_PATH ),
+);
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( __DIR__ ) . '/'.PLUGIN_NAME;
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/lib/router.php
+++ b/tests/lib/router.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * This is router for built-in php server. It is designed to use only for testing
+ * This frees us from installing apache or nginx in travis
+ * Usage: $ php -S 0.0.0.0:12000 router.php
+ */
+
+$root = $_SERVER['DOCUMENT_ROOT'];
+
+$path = '/'. ltrim( parse_url( urldecode( $_SERVER['REQUEST_URI'] ) )['path'], '/' );
+
+$requestfile = NULL;
+
+// Search for request file
+if(file_exists( $root.$path )) {
+  $requestfile = $root.$path;
+} else {
+  // Check if wordpress core is installed in subdirectory by searching files in one subdirectory below
+  // This makes it work with composer installed wordpress too
+  foreach(scandir($root) as $file) {
+    if($file == '.' || $file == '..') continue;
+    $filename = '/'.$file.$path;
+    if(file_exists( $root.$filename )) {
+
+      // Check if assets are in subfolder
+      if (preg_match('/\.(?:png|jpg|jpeg|gif|css|js|svg|min|ttf|swf|xml)$/', $_SERVER["SCRIPT_NAME"])) {
+        // We can't rewrite assets but we can redirect them
+        header("Location: $filename");
+        exit();
+      }
+      $requestfile = $root.$filename;
+      break;
+    }
+  }
+}
+
+// In testing environment use whatever we get as hostname
+define('WP_HOME',    'http://'.$_SERVER['HTTP_HOST']);
+define('WP_SITEURL', 'http://'.$_SERVER['HTTP_HOST']);
+
+// We can't use https in travis
+define('FORCE_SSL_ADMIN', false);
+
+if ( $requestfile ) {
+  if ( is_dir( $requestfile ) && substr( $path, -1 ) !== '/' ) {
+    header( "Location: $path/" );
+    exit;
+  }
+  if ( strpos( $path, '.php' ) !== false ) {
+    chdir( dirname( $requestfile ) );
+    require_once basename($requestfile); // If file exists just use it!
+  } elseif(is_dir($requestfile)) {
+    chdir( dirname( $requestfile ) );
+    require_once 'index.php'; // If this was a folder use index.php instead
+  } else {
+    return false; // This just means to return file as is
+  }
+} else {
+  chdir( $root );
+  require_once 'index.php';
+}

--- a/tests/lib/router.php
+++ b/tests/lib/router.php
@@ -1,5 +1,6 @@
 <?php
-/*
+// @codingStandardsIgnoreStart
+/**
  * This is router for built-in php server. It is designed to use only for testing
  * This frees us from installing apache or nginx in travis
  * Usage: $ php -S 0.0.0.0:12000 router.php
@@ -9,53 +10,54 @@ $root = $_SERVER['DOCUMENT_ROOT'];
 
 $path = '/'. ltrim( parse_url( urldecode( $_SERVER['REQUEST_URI'] ) )['path'], '/' );
 
-$requestfile = NULL;
+$requestfile = null;
 
 // Search for request file
-if(file_exists( $root.$path )) {
-  $requestfile = $root.$path;
+if ( file_exists( $root.$path ) ) {
+	$requestfile = $root.$path;
 } else {
-  // Check if wordpress core is installed in subdirectory by searching files in one subdirectory below
-  // This makes it work with composer installed wordpress too
-  foreach(scandir($root) as $file) {
-    if($file == '.' || $file == '..') continue;
-    $filename = '/'.$file.$path;
-    if(file_exists( $root.$filename )) {
+	// Check if wordpress core is installed in subdirectory by searching files in one subdirectory below
+	// This makes it work with composer installed wordpress too
+	foreach ( scandir( $root ) as $file ) {
+		if ( $file == '.' || $file == '..' ) { continue; }
+		$filename = '/'.$file.$path;
+		if ( file_exists( $root.$filename ) ) {
 
-      // Check if assets are in subfolder
-      if (preg_match('/\.(?:png|jpg|jpeg|gif|css|js|svg|min|ttf|swf|xml)$/', $_SERVER["SCRIPT_NAME"])) {
-        // We can't rewrite assets but we can redirect them
-        header("Location: $filename");
-        exit();
-      }
-      $requestfile = $root.$filename;
-      break;
-    }
-  }
+			// Check if assets are in subfolder
+			if ( preg_match( '/\.(?:png|jpg|jpeg|gif|css|js|svg|min|ttf|swf|xml)$/', $_SERVER['SCRIPT_NAME'] ) ) {
+				// We can't rewrite assets but we can redirect them
+				header( "Location: $filename" );
+				exit();
+			}
+			$requestfile = $root.$filename;
+			break;
+		}
+	}
 }
 
 // In testing environment use whatever we get as hostname
-define('WP_HOME',    'http://'.$_SERVER['HTTP_HOST']);
-define('WP_SITEURL', 'http://'.$_SERVER['HTTP_HOST']);
+define( 'WP_HOME',    'http://'.$_SERVER['HTTP_HOST'] );
+define( 'WP_SITEURL', 'http://'.$_SERVER['HTTP_HOST'] );
 
 // We can't use https in travis
-define('FORCE_SSL_ADMIN', false);
+define( 'FORCE_SSL_ADMIN', false );
 
 if ( $requestfile ) {
-  if ( is_dir( $requestfile ) && substr( $path, -1 ) !== '/' ) {
-    header( "Location: $path/" );
-    exit;
-  }
-  if ( strpos( $path, '.php' ) !== false ) {
-    chdir( dirname( $requestfile ) );
-    require_once basename($requestfile); // If file exists just use it!
-  } elseif(is_dir($requestfile)) {
-    chdir( dirname( $requestfile ) );
-    require_once 'index.php'; // If this was a folder use index.php instead
-  } else {
-    return false; // This just means to return file as is
-  }
+	if ( is_dir( $requestfile ) && substr( $path, -1 ) !== '/' ) {
+		header( "Location: $path/" );
+		exit;
+	}
+	if ( strpos( $path, '.php' ) !== false ) {
+		chdir( dirname( $requestfile ) );
+		require_once basename( $requestfile ); // If file exists just use it!
+	} elseif ( is_dir( $requestfile ) ) {
+		chdir( dirname( $requestfile ) );
+		require_once 'index.php'; // If this was a folder use index.php instead
+	} else {
+		return false; // This just means to return file as is
+	}
 } else {
-  chdir( $root );
-  require_once 'index.php';
+	chdir( $root );
+	require_once 'index.php';
 }
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
I've run automated phpcs fixer for all the spaces and the other stuff. basically, it is `grunt phpcbf`
Then I manually worked on settings-page.php
the changes there are escaping almost everything that come from the database - especially the options. But other static text string. to escape static text is a little dumb, but it can prevent a rare XSS through .po files and it is also required by the coding standards.
settings-page.php is Lint free now!