### PR TITLE
Update wordpress-notifications.php

### DIFF
--- a/classes/wordpress-notifications.php
+++ b/classes/wordpress-notifications.php
@@ -86,7 +86,7 @@ if ( ! class_exists( WPNotifications ) ) {
 			$currentVersion = wp_get_theme()->get( 'Version' );
 			$currentTheme   = get_option( 'template' );
 
-			if ( $versionCheck->response[ $currentTheme ]['new_version'] !== $currentVersion ) {
+			if ( $versionCheck->response[ $currentTheme ]['new_version'] !== $currentVersion && !is_null( $versionCheck->response[ $currentTheme ]['new_version'] ) ) {
 
 				$newVersion = $versionCheck->response[ $currentTheme ]['new_version'];
 


### PR DESCRIPTION
When we use a self hosted api for updates, there is an option the
api will not return any answer and $versionCheck->response[ $currentTheme ]['new_version'] will equal to null.