### PR TITLE
Add support for post formats, exclude tags/categories items when empty

### DIFF
--- a/core/notifications/class-post.php
+++ b/core/notifications/class-post.php
@@ -160,17 +160,31 @@ class Post extends Notification_Type {
 				'value' => get_the_date( null, $post->ID ),
 				'short' => true,
 			],
-			[
-				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'category' ),
-				'short' => false,
-			],
-			[
-				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'post_tag' ),
-				'short' => false,
-			],
 		];
+
+		if ( $format = get_post_format($post) ) {
+			$attachments[] =  [
+				'title' => esc_html__( 'Post Format', 'dorzki-notifications-to-slack' ),
+				'value' => ucwords($format),
+				'short' => true,
+			];
+		}
+
+		if ( $categories = $this->get_post_terms( $post, 'category' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
+				'value' => $categories,
+				'short' => false,
+			];
+		}
+
+		if ( $tags = $this->get_post_terms( $post, 'post_tag' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
+				'value' => $tags,
+				'short' => false,
+			];
+		}
 
 		$channel = $this->get_notification_channel( __FUNCTION__ );
 
@@ -224,17 +238,31 @@ class Post extends Notification_Type {
 				'value' => get_the_time( null, $post->ID ),
 				'short' => true,
 			],
-			[
-				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'category' ),
-				'short' => false,
-			],
-			[
-				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'post_tag' ),
-				'short' => false,
-			],
 		];
+
+		if ( $format = get_post_format($post) ) {
+			$attachments[] =  [
+				'title' => esc_html__( 'Post Format', 'dorzki-notifications-to-slack' ),
+				'value' => ucwords($format),
+				'short' => true,
+			];
+		}
+
+		if ( $categories = $this->get_post_terms( $post, 'category' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
+				'value' => $categories,
+				'short' => false,
+			];
+		}
+
+		if ( $tags = $this->get_post_terms( $post, 'post_tag' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
+				'value' => $tags,
+				'short' => false,
+			];
+		}
 
 		$channel = $this->get_notification_channel( __FUNCTION__ );
 
@@ -283,17 +311,31 @@ class Post extends Notification_Type {
 				'value' => get_the_date( null, $post->ID ),
 				'short' => true,
 			],
-			[
-				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'category' ),
-				'short' => false,
-			],
-			[
-				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'post_tag' ),
-				'short' => false,
-			],
 		];
+
+		if ( $format = get_post_format($post) ) {
+			$attachments[] =  [
+				'title' => esc_html__( 'Post Format', 'dorzki-notifications-to-slack' ),
+				'value' => ucwords($format),
+				'short' => true,
+			];
+		}
+
+		if ( $categories = $this->get_post_terms( $post, 'category' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
+				'value' => $categories,
+				'short' => false,
+			];
+		}
+
+		if ( $tags = $this->get_post_terms( $post, 'post_tag' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
+				'value' => $tags,
+				'short' => false,
+			];
+		}
 
 		$channel = $this->get_notification_channel( __FUNCTION__ );
 
@@ -345,17 +387,31 @@ class Post extends Notification_Type {
 				'value' => get_the_modified_date( null, $post->ID ),
 				'short' => true,
 			],
-			[
-				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'category' ),
-				'short' => false,
-			],
-			[
-				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'post_tag' ),
-				'short' => false,
-			],
 		];
+
+		if ( $format = get_post_format($post) ) {
+			$attachments[] =  [
+				'title' => esc_html__( 'Post Format', 'dorzki-notifications-to-slack' ),
+				'value' => ucwords($format),
+				'short' => true,
+			];
+		}
+
+		if ( $categories = $this->get_post_terms( $post, 'category' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
+				'value' => $categories,
+				'short' => false,
+			];
+		}
+
+		if ( $tags = $this->get_post_terms( $post, 'post_tag' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
+				'value' => $tags,
+				'short' => false,
+			];
+		}
 
 		$channel = $this->get_notification_channel( __FUNCTION__ );
 
@@ -407,17 +463,31 @@ class Post extends Notification_Type {
 				'value' => get_the_modified_date( null, $post->ID ),
 				'short' => true,
 			],
-			[
-				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'category' ),
-				'short' => false,
-			],
-			[
-				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
-				'value' => $this->get_post_terms( $post, 'post_tag' ),
-				'short' => false,
-			],
 		];
+
+		if ( $format = get_post_format($post) ) {
+			$attachments[] =  [
+				'title' => esc_html__( 'Post Format', 'dorzki-notifications-to-slack' ),
+				'value' => ucwords($format),
+				'short' => true,
+			];
+		}
+
+		if ( $categories = $this->get_post_terms( $post, 'category' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Categories', 'dorzki-notifications-to-slack' ),
+				'value' => $categories,
+				'short' => false,
+			];
+		}
+
+		if ( $tags = $this->get_post_terms( $post, 'post_tag' ) ) {
+			$attachments[] = [
+				'title' => esc_html__( 'Post Tags', 'dorzki-notifications-to-slack' ),
+				'value' => $tags,
+				'short' => false,
+			];
+		}
 
 		$channel = $this->get_notification_channel( __FUNCTION__ );
 


### PR DESCRIPTION
Hi! This adds a "Post Format" attachment to the notification when a post has a post format other than "Standard". It also restructures the logic to exclude "Post Tags" or "Post Categories" from notification attachments if the post doesn't have any tags or categories, preventing this:

![CleanShot 2022-09-09 at 10 21 22](https://user-images.githubusercontent.com/1672206/189385308-6c868adb-f70a-44d1-8ca8-0254aaf114b3.png)
